### PR TITLE
Fix links to endpoint response pages

### DIFF
--- a/static/tour/latest-release/index.html
+++ b/static/tour/latest-release/index.html
@@ -8,7 +8,7 @@ title: Take a tour of the API
 <section data-tour-endpoint="/datasets/cpih01" class="static section__content--static-markdown">
 
     <p>Once you have a dataset ID, you can find the latest release of a dataset using the <a
-            href="../../dataset/datasets-{id}/">get dataset</a> endpoint.</p>
+            href="../../dataset/datasets-id/">get dataset</a> endpoint.</p>
 
     <p>A link to the latest release can be found in <tt>links.latest_version</tt> field.</p>
 

--- a/static/tour/latest-version/index.html
+++ b/static/tour/latest-version/index.html
@@ -9,7 +9,7 @@ title: Take a tour of the API
         class="static section__content--static-markdown">
     <p>
         Once you have the link to the latest release, you can fetch its metadata using the
-        <a href="../../dataset/datasets-{id}-editions-{edition}-versions-{version}">get version</a> endpoint
+        <a href="../../dataset/datasets-id-editions-edition-versions-version">get version</a> endpoint
         using the URL from <tt>links.latest_version</tt>.
     </p>
 

--- a/static/tour/series-data-point/index.html
+++ b/static/tour/series-data-point/index.html
@@ -7,7 +7,7 @@ title: Take a tour of the API
 </h2>
 <section data-tour-endpoint="/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0" class="static section__content--static-markdown">
     <p>You can also get a series of data points using the <a
-            href="../../dataset/datasets-{id}-editions-{edition}-versions-{version}-observations/">get observation</a>
+            href="../../dataset/datasets-id-editions-edition-versions-version-observations/">get observation</a>
         endpoint.</p>
 
     <p>By making one of the dimensions values a wildcard, multiple data points are returned.</p>

--- a/static/tour/single-data-point/index.html
+++ b/static/tour/single-data-point/index.html
@@ -7,7 +7,7 @@ title: Take a tour of the API
 </h2>
 <section data-tour-endpoint="/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0" class="static section__content--static-markdown">
     <p>Once you have a link to the latest release, you can get a specific data point from the release using the <a
-            href="../../dataset/datasets-{id}-editions-{edition}-versions-{version}-observations/">get observation</a>
+            href="../../dataset/datasets-id-editions-edition-versions-version-observations/">get observation</a>
         endpoint.</p>
 
     <p>You need to specify a value for each of the available dimensions using query string parameters.</p>


### PR DESCRIPTION
### What

Fix links to endpoint response pages in the tour. URLs were sanitised to remove encoding for { and } characters as per another PR; this change ensures that the links will go to the pages rather than 404.

### How to review

Check that { and } have been removed from each of the tour static pages

### Who can review

Anyone bar me
