### PR TITLE
fix formatting for ons api link

### DIFF
--- a/static/index.md
+++ b/static/index.md
@@ -4,7 +4,7 @@ title: Introduction
 
 The Office for National Statistics API makes datasets and other data available programmatically using HTTP. It allows you to filter datasets and directly access specific data points.
 
-<p style="font-size: 21px">The API is available at `https://api.beta.ons.gov.uk/v1`</p>
+<p style="font-size: 21px">The API is available at <code>https://api.beta.ons.gov.uk/v1</code></p>
 
 The API is open and unrestricted - no API keys are required, so you can start using it immediately.
 


### PR DESCRIPTION
### What

Fixed formatting of ONS API URL. Due to requiring html in the Markdown in order to increase font size, the backticks no longer formatted the URL as intended.

### How to review

Check markup aligns with what's required

### Who can review

Anyone bar me
