### PR TITLE
Fix link to tour from the introduction page bug - live only

### DIFF
--- a/static/index.md
+++ b/static/index.md
@@ -9,7 +9,7 @@ The Office for National Statistics API makes datasets and other data available p
 The API is open and unrestricted - no API keys are required, so you can start using it immediately.
 
 <div>
-    <a class = "btn btn--primary btn--bold margin-bottom-md--2" href="tour/getting-started">Take a tour of the API</a>
+    <a class = "btn btn--primary btn--bold margin-bottom-md--2" href="tour/getting-started/">Take a tour of the API</a>
 </div>
 
 **This API is currently in Beta and still being developed. Please be aware that as a result of this there may occasionally be breaking changes as we enhance functionality and respond to feedback.**


### PR DESCRIPTION
### What

"Take a tour of the API" button on the introduction page was not routing to the tour and instead going to a 404. 

This was only happening on the live site and not locally so wasn't spotted beforehand; the fix was to add a `/` to the end of the `href` for that link.

### How to review

- Check markup
- You can see this 'fix' on live too if you go to the [developer site](https://developer.beta.ons.gov.uk/), inspect the "Take a tour of the API" button and update the `href` to `tour/getting-started/`

### Who can review

Anyone bar me