### PR TITLE
Feature/remove gtm update footer

### DIFF
--- a/scss/elements/_banner.scss
+++ b/scss/elements/_banner.scss
@@ -1,0 +1,13 @@
+.banner {
+    &--blue {
+        background: #3B7A9E;
+    }
+
+    &__text {
+        color: #fff;
+
+        a {
+            color: #fff;
+        }
+    }
+}

--- a/scss/elements/_banner.scss
+++ b/scss/elements/_banner.scss
@@ -10,4 +10,8 @@
             color: #fff;
         }
     }
+
+    &__text-icon {
+        background-color: #414042;
+    }
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,6 +1,7 @@
 @import 'base/_variables.scss';
 @import 'base/_breakpoints.scss';
 
+@import 'elements/_banner.scss';
 @import 'elements/_headings.scss';
 @import 'elements/_tables.scss';
 @import 'elements/_global.scss';

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -11,36 +11,12 @@
         </title>
         <link rel="preload" as="font"  type="font/woff2" href="https://cdn.ons.gov.uk/assets/fonts/open-sans-regular/OpenSans-Regular-webfont.woff2" crossorigin>
         <link rel="preload" as="font"  type="font/woff2" href="https://cdn.ons.gov.uk/assets/fonts/open-sans-bold/OpenSans-Bold-webfont.woff2" crossorigin>
-        <link rel="stylesheet" href="https://cdn.ons.gov.uk/sixteens/eb938ca/css/main.css">
+        <link rel="stylesheet" href="https://cdn.ons.gov.uk/sixteens/60c47e5/css/main.css">
         <link rel="stylesheet" href="https://jmblog.github.io/color-themes-for-google-code-prettify/themes/tomorrow-night.min.css">
         <link rel="stylesheet" href="{{$rootPath}}assets/css/main.css">
-        <!-- Google Tag Manager -->
-        <script>
-            (function (w, d, s, l, i) {
-                w[l] = w[l] || [];
-                w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = d.getElementsByTagName(s)[0],
-                    j = d.createElement(s),
-                    dl = l != 'dataLayer'
-                        ? '&l=' + l
-                        : '';
-                j.async = true;
-                j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-                f
-                    .parentNode
-                    .insertBefore(j, f);
-            })(window, document, 'script', 'dataLayer', 'GTM-MBCBVQS');
-        </script>
-        <!-- End Google Tag Manager -->
     </head>
-    <body class="adjust-font-size--16 link-adjust sticky-footer">
-        <header class="border-bottom--iron-sm border-bottom--iron-md">
-            <!-- Google Tag Manager (noscript) -->
-            <noscript>
-                <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
-                            height="0" width="0" style="display:none;visibility:hidden"></iframe>
-            </noscript>
-            <!-- End Google Tag Manager (noscript) -->
+    <body class="link-adjust sticky-footer">
+        <header class="adjust-font-size--16 border-bottom--iron-sm border-bottom--iron-md">
             <a class="skiplink" href="#main" tabindex="0">Skip to main content</a>
             <div class="wrapper">
                 <div class="header col-wrap">
@@ -54,19 +30,19 @@
                     </div>
                 </div>
             </div>
-            <div class="banner">
+            <div class="banner banner--blue">
                 <div class="wrapper">
                     <div class="col col--md-40 col--lg-44">
                         <span class="banner__text-icon">Beta</span>
                         <div class="banner__body">
-                            <p>This is a new way of getting data - your <a href="/feedback?service=dev">feedback</a> will help
+                            <p class="banner__text">This is a new way of getting data - your <a href="/feedback?service=dev">feedback</a> will help
                             us to improve it.</p>
                         </div>
                     </div>
                 </div>
             </div>
         </header>
-        <main id="main" role="main" tabindex="-1">
+        <main class="adjust-font-size--16" id="main" role="main" tabindex="-1">
             <div class="wrapper margin-bottom-sm--3 margin-bottom-md--6">
                 <div class="col-wrap">
                     <div class="col col--md-one-half col--lg-one-third sticky sticky--lg-only">
@@ -155,9 +131,14 @@
                                     <li class="footer-nav__item">
                                         <a href="/help/accessibility">Accessibility</a>
                                     </li>
+
                                     <li class="footer-nav__item">
-                                        <a href="/help/cookiesandprivacy">Cookies and privacy</a>
+                                        <a href="/cookies">Cookies</a>
                                     </li>
+                                    <li class="footer-nav__item">
+                                        <a href="/help/privacy">Privacy</a>
+                                    </li>
+
                                     <li class="footer-nav__item">
                                         <a href="/help/termsandconditions">Terms and conditions</a>
                                     </li>
@@ -217,6 +198,6 @@
         <script>
             window.feedbackOrigin = "https://beta.ons.gov.uk"
         </script>
-        <script src="https://cdn.ons.gov.uk/sixteens/eb938ca/js/main.js"></script>
+        <script src="https://cdn.ons.gov.uk/sixteens/60c47e5/js/main.js"></script>
     </body>
 </html>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -136,7 +136,7 @@
                                         <a href="/cookies">Cookies</a>
                                     </li>
                                     <li class="footer-nav__item">
-                                        <a href="/help/privacy">Privacy</a>
+                                        <a href="/help/privacynotice">Privacy</a>
                                     </li>
 
                                     <li class="footer-nav__item">

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -140,7 +140,7 @@
                                     </li>
 
                                     <li class="footer-nav__item">
-                                        <a href="https://www.ons.gov.uk/help/accessibility">Terms and conditions</a>
+                                        <a href="https://www.ons.gov.uk/help/termsandconditions">Terms and conditions</a>
                                     </li>
                                 </ul>
                             </div>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -47,7 +47,7 @@
                 <div class="col-wrap">
                     <div class="col col--md-one-half col--lg-one-third sticky sticky--lg-only">
                         <div class="margin-top-sm--4 margin-top-md--5 margin-right-lg--2 padding-top--1 padding-right--1 padding-bottom--1 padding-left--1 background--iron-light">
-                            <h2 class="font-size--18 margin-top--2">
+                            <h2 class="margin-top--2">
                                 <strong>Contents:</strong>
                             </h2>
                             <nav>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -129,18 +129,18 @@
                                 <h3 class="footer-nav__heading">Help</h3>
                                 <ul class="footer-nav__list">
                                     <li class="footer-nav__item">
-                                        <a href="/help/accessibility">Accessibility</a>
+                                        <a href="https://www.ons.gov.uk/help/accessibility">Accessibility</a>
                                     </li>
 
                                     <li class="footer-nav__item">
-                                        <a href="/cookies">Cookies</a>
+                                        <a href="https://www.ons.gov.uk/cookies">Cookies</a>
                                     </li>
                                     <li class="footer-nav__item">
-                                        <a href="/help/privacynotice">Privacy</a>
+                                        <a href="https://www.ons.gov.uk/help/privacynotice">Privacy</a>
                                     </li>
 
                                     <li class="footer-nav__item">
-                                        <a href="/help/termsandconditions">Terms and conditions</a>
+                                        <a href="https://www.ons.gov.uk/help/accessibility">Terms and conditions</a>
                                     </li>
                                 </ul>
                             </div>
@@ -148,19 +148,16 @@
                                 <h3 class="footer-nav__heading">About ONS</h3>
                                 <ul class="footer-nav__list">
                                     <li class="footer-nav__item">
-                                        <a href="/aboutus/whatwedo">What we do</a>
+                                        <a href="https://www.ons.gov.uk/aboutus/whatwedo">What we do</a>
                                     </li>
                                     <li class="footer-nav__item">
-                                        <a href="/aboutus/careers">Careers</a>
+                                        <a href="https://www.ons.gov.uk/aboutus/careers">Careers</a>
                                     </li>
                                     <li class="footer-nav__item">
-                                        <a href="/aboutus/contactus">Contact us</a>
+                                        <a href="https://www.ons.gov.uk/aboutus/contactus">Contact us</a>
                                     </li>
                                     <li class="footer-nav__item">
-                                        <a href="/news">News</a>
-                                    </li>
-                                    <li class="footer-nav__item">
-                                        <a href="/aboutus/transparencyandgovernance/freedomofinformationfoi">Freedom of Information</a>
+                                        <a href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi">Freedom of Information</a>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
### What

This PR removes the GTM script from the markup and updates the footer to match with the current ONS one.

Updating the footer meant pulling in the new styles of Sixteens which required some additional changes. Most notably, the addition of a new `_banner` sass partial which contains the old styling of the beta banner. This is because the banner styling on the main ONS page has been updated to a new pattern.

### How to review

- Check that instances of GTM within the codebase are removed
- Check that the page styling looks fine
- Check that the footer matches the one on the main ONS site

### Who can review

Anyone but me
