### PR TITLE
Update urls for API specs to read from master rather than develop

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,11 +114,11 @@ var Tags = tags{
 
 func main() {
 	sources := spec.APIs{
-		{"dataset-api", "https://raw.githubusercontent.com/ONSdigital/dp-dataset-api/develop/swagger.yaml", nil, nil},
-		{"filter-api", "https://raw.githubusercontent.com/ONSdigital/dp-filter-api/develop/swagger.yaml", nil, nil},
-		{"code-list-api", "https://raw.githubusercontent.com/ONSdigital/dp-code-list-api/develop/swagger.yaml", nil, nil},
-		{"hierarchy-api", "https://raw.githubusercontent.com/ONSdigital/dp-hierarchy-api/develop/swagger.yaml", nil, nil},
-		{"search-api", "https://raw.githubusercontent.com/ONSdigital/dp-search-api/develop/swagger.yaml", nil, nil},
+		{"dataset-api", "https://raw.githubusercontent.com/ONSdigital/dp-dataset-api/master/swagger.yaml", nil, nil},
+		{"filter-api", "https://raw.githubusercontent.com/ONSdigital/dp-filter-api/master/swagger.yaml", nil, nil},
+		{"code-list-api", "https://raw.githubusercontent.com/ONSdigital/dp-code-list-api/master/swagger.yaml", nil, nil},
+		{"hierarchy-api", "https://raw.githubusercontent.com/ONSdigital/dp-hierarchy-api/master/swagger.yaml", nil, nil},
+		{"search-api", "https://raw.githubusercontent.com/ONSdigital/dp-search-api/master/swagger.yaml", nil, nil},
 	}
 
 	if err := sources.Load(); err != nil {


### PR DESCRIPTION
### What

- Updated the urls for the API specs so they read from the master branch rather than develop
- I haven't included any dependancies update as they have been updated in #32 

### How to review

- Check that data still loads across the developer site pages

### Who can review

- Anyone but me