### PR TITLE
Improve screen reader usability of API tour

### DIFF
--- a/js/tests/tour/CodeExamples.spec.js
+++ b/js/tests/tour/CodeExamples.spec.js
@@ -1,4 +1,4 @@
-import { toggleCodeExample } from '../../tour/CodeExamples';
+import {toggleCodeExample} from '../../tour/CodeExamples';
 
 describe('displaying the code example', () => {
   const exampleContainer = document.createElement('div');

--- a/js/tour/CodeExamples.js
+++ b/js/tour/CodeExamples.js
@@ -29,4 +29,4 @@ const buildCodeExample = (container, url) => {
   container.appendChild(codeBlock);
 };
 
-export { toggleCodeExample, buildCodeExample };
+export {toggleCodeExample, buildCodeExample};

--- a/js/tour/Results.js
+++ b/js/tour/Results.js
@@ -22,6 +22,7 @@ const buildResultsView = (el, response, resultType) => {
     case 'jsonOnly':
       return;
   }
+  window.location.hash = 'results-section';
 };
 
 const buildTableBody = (resultsContainer, data) => {

--- a/js/tour/index.js
+++ b/js/tour/index.js
@@ -1,8 +1,8 @@
-import { toggleCodeExample } from './CodeExamples';
-import { fetchData } from './FetchData';
-import { buildJSONView, buildResultsView } from './Results';
-import { initialiseTabFunctionality } from '../utils/tabs';
-import { setVisibility } from '../utils/setVisibility';
+import {toggleCodeExample} from './CodeExamples';
+import {fetchData} from './FetchData';
+import {buildJSONView, buildResultsView} from './Results';
+import {initialiseTabFunctionality} from '../utils/tabs';
+import {setVisibility} from '../utils/setVisibility';
 
 export default function tourInit() {
   // Build API URL
@@ -14,19 +14,20 @@ export default function tourInit() {
   const exampleLabel = document.querySelector('[data-tour-example-label]');
   const exampleContainer = document.querySelector('[data-tour-example-block]');
 
-  exampleDetails.addEventListener('toggle', function () {
+  exampleDetails.addEventListener('toggle', function() {
     toggleCodeExample(exampleDetails, exampleLabel, exampleContainer, url);
   });
 
   // Results Views
   const tryItOut = document.querySelector('[data-tour-tryitout=\'button\']');
+  const resultsSection = document.querySelector('[data-tour-tryitout-results]');
   const errorContainer = document.querySelector('[data-tour=\'error\'');
   const resultsContainer = document.querySelector('[data-tour-tryitout=\'results\']');
   const resultsOutputContainer = document.querySelector('[data-tour-results-type]');
   const jsonContainer = document.querySelector('[data-tour-results-view=\'json\'] > .markdown > pre');
   let resultsData;
 
-  tryItOut.addEventListener('click', async function () {
+  tryItOut.addEventListener('click', async function() {
     setVisibility(errorContainer, false);
     initialiseTabFunctionality(resultsContainer);
     // Fetch data; disable Try It Out button while waiting for response/error
@@ -35,13 +36,13 @@ export default function tourInit() {
 
     try {
       resultsData = await fetchData(url);
-      setVisibility(resultsContainer, true);
-      tryItOut.classList.remove('btn--primary-disabled');
+      setVisibility(resultsSection, true);
 
       // Get results type string. If none present, assume current page of tour does not have a Results section and default to 'jsonOnly'
       const resultsType = resultsOutputContainer ? resultsOutputContainer.dataset.tourResultsType : 'jsonOnly';
       buildJSONView(jsonContainer, resultsData);
       buildResultsView(resultsOutputContainer, resultsData, resultsType);
+      setVisibility(resultsContainer, true);
     } catch {
       tryItOut.removeAttribute('disabled');
       tryItOut.classList.remove('btn--primary-disabled');

--- a/static/tour/getting-started/index.html
+++ b/static/tour/getting-started/index.html
@@ -9,10 +9,11 @@ title: Take a tour of the API
     <p>You can get a list of datasets using the <a href="../../dataset/datasets/">list datasets</a>
         endpoint.</p>
 
-    <section>
-        <h3>Example</h3>
+    <section aria-labelledby="example-heading">
+        <h3 id="example-heading">Example</h3>
         <p>
-            Make a <code>GET</code> request to <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets</code>
+            Make a <code>GET</code> request to <code
+                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">
@@ -29,39 +30,44 @@ title: Take a tour of the API
                     class="line-height--32">Run this JavaScript example</span></button>
         </div>
 
-        <div class="hidden margin-top--2" data-tour="error" role="alert">
-            <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
-                An error occurred when trying to display results. Please try again.
-            </div>
-        </div>
-
-        <div class="hidden margin-top--2" data-tour-tryitout="results">
-            <div class="btn-group tour__tabs" role="tablist">
-                <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
-                    class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
-                    data-tour-results-tab="json">JSON</a>
-                <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
-                    class="btn btn--secondary btn--chart-control tour__tab" data-tour-results-tab="results">Content</a>
-            </div>
-            <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
-                aria-labelledby="json-tab" aria-hidden="false">
-                <div class="markdown">
-                    <pre class="tour__json-container" tabIndex="0"></pre>
+        <section id="results-section" class="hidden" tabindex="-1" aria-labelledby="results-heading"
+            data-tour-tryitout-results>
+            <h4 id="results-heading">Results</h4>
+            <div class="hidden margin-top--2" data-tour="error" role="alert">
+                <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
+                    An error occurred when trying to display results. Please try again.
                 </div>
             </div>
-            <div id="results" data-tour-results-view="results" tabindex="0" class="tour__results-container"
-                role="tabpanel" aria-labelledby="results-tab" aria-hidden="true">
-                <table class="tour-table">
-                    <thead>
-                        <tr class="tour-table__header-row">
-                            <th class="tour-table__header-cell">Dataset ID</th>
-                            <th class="tour-table__header-cell">Title</th>
-                        </tr>
-                    </thead>
-                    <tbody data-tour-results-type="table"></tbody>
-                </table>
+
+            <div class="hidden margin-top--2" data-tour-tryitout="results">
+                <div class="btn-group tour__tabs" role="tablist">
+                    <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
+                        class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
+                        data-tour-results-tab="json">JSON</a>
+                    <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
+                        class="btn btn--secondary btn--chart-control tour__tab"
+                        data-tour-results-tab="results">Content</a>
+                </div>
+                <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
+                    aria-labelledby="json-tab" aria-hidden="false">
+                    <div class="markdown">
+                        <pre class="tour__json-container" tabIndex="0"></pre>
+                    </div>
+                </div>
+                <div id="results" data-tour-results-view="results" tabindex="0" class="tour__results-container"
+                    role="tabpanel" aria-labelledby="results-tab" aria-hidden="true">
+                    <table class="tour-table">
+                        <thead>
+                            <tr class="tour-table__header-row">
+                                <th class="tour-table__header-cell">Dataset ID</th>
+                                <th class="tour-table__header-cell">Title</th>
+                            </tr>
+                        </thead>
+                        <tbody data-tour-results-type="table"></tbody>
+                    </table>
+                </div>
             </div>
-        </div>
+        </section>
     </section>
     <hr class="margin-top--3">
     <nav class="margin-top--2">

--- a/static/tour/latest-release/index.html
+++ b/static/tour/latest-release/index.html
@@ -12,10 +12,11 @@ title: Take a tour of the API
 
     <p>A link to the latest release can be found in <code>links.latest_version</code> field.</p>
 
-    <div>
-        <h3>Example</h3>
+    <section aria-labelledby="example-heading">
+        <h3 id="example-heading">Example</h3>
         <p>
-            Make a <code>GET</code> request to <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01</code>
+            Make a <code>GET</code> request to <code
+                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">
@@ -32,34 +33,39 @@ title: Take a tour of the API
                     class="line-height--32">Run this JavaScript example</span></button>
         </div>
 
-        <div class="hidden margin-top--2" data-tour="error" role="alert">
-            <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
-                An error occurred when trying to display results. Please try again.
-            </div>
-        </div>
-
-        <div class="hidden margin-top--2" data-tour-tryitout="results">
-            <div class="btn-group tour__tabs" role="tablist">
-                <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
-                    class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
-                    data-tour-results-tab="json">JSON</a>
-                <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
-                    class="btn btn--secondary btn--chart-control tour__tab" data-tour-results-tab="results">Content</a>
-            </div>
-            <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
-                aria-labelledby="json-tab" aria-hidden="false">
-                <div class="markdown">
-                    <pre class="tour__json-container" tabIndex="0"></pre>
+        <section id="results-section" class="hidden" tabindex="-1" aria-labelledby="results-heading"
+            data-tour-tryitout-results>
+            <h4 id="results-heading">Results</h4>
+            <div class="hidden margin-top--2" data-tour="error" role="alert">
+                <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
+                    An error occurred when trying to display results. Please try again.
                 </div>
             </div>
-            <p id="results" data-tour-results-view="results" data-tour-results-type="latestRelease" tabindex="0"
-                class="tour__results-container" role="tabpanel" aria-labelledby="results-tab" aria-hidden="true"></p>
-        </div>
 
-        <hr class="margin-top--3">
-        <nav class="margin-top--2">
-            <a class="float-left" href="../getting-started/">Previous: Getting Started</a>
-            <a class="float-right" href="../latest-version/">Next: Get the latest version</a>
-        </nav>
-    </div>
+            <div class="hidden margin-top--2" data-tour-tryitout="results">
+                <div class="btn-group tour__tabs" role="tablist">
+                    <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
+                        class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
+                        data-tour-results-tab="json">JSON</a>
+                    <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
+                        class="btn btn--secondary btn--chart-control tour__tab"
+                        data-tour-results-tab="results">Content</a>
+                </div>
+                <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
+                    aria-labelledby="json-tab" aria-hidden="false">
+                    <div class="markdown">
+                        <pre class="tour__json-container" tabIndex="0"></pre>
+                    </div>
+                </div>
+                <p id="results" data-tour-results-view="results" data-tour-results-type="latestRelease" tabindex="0"
+                    class="tour__results-container" role="tabpanel" aria-labelledby="results-tab" aria-hidden="true">
+                </p>
+            </div>
+        </section>
+    </section>
+    <hr class="margin-top--3">
+    <nav class="margin-top--2">
+        <a class="float-left" href="../getting-started/">Previous: Getting Started</a>
+        <a class="float-right" href="../latest-version/">Next: Get the latest version</a>
+    </nav>
 </section>

--- a/static/tour/latest-version/index.html
+++ b/static/tour/latest-version/index.html
@@ -13,11 +13,12 @@ title: Take a tour of the API
         using the URL from <code>links.latest_version</code>.
     </p>
 
-    <section>
-        <h3>Example</h3>
+    <section aria-labelledby="example-heading">
+        <h3 id="example-heading">Example</h3>
         <p>
             Make a <code>GET</code> request to
-            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6</code>
+            <code
+                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">
@@ -34,25 +35,29 @@ title: Take a tour of the API
                     class="line-height--32">Run this JavaScript example</span></button>
         </div>
 
-        <div class="hidden margin-top--2" data-tour="error" role="alert">
-            <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
-                An error occurred when trying to display results. Please try again.
-            </div>
-        </div>
-
-        <div class="hidden margin-top--2" data-tour-tryitout="results">
-            <div class="btn-group tour__tabs" role="tablist">
-                <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
-                    class="btn btn--secondary btn--chart-control btn--secondary-active"
-                    data-tour-results-tab="json">JSON</a>
-            </div>
-            <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
-                aria-labelledby="json-tab" aria-hidden="false">
-                <div class="markdown">
-                    <pre class="tour__json-container" tabIndex="0"></pre>
+        <section id="results-section" class="hidden" tabindex="-1" aria-labelledby="results-heading"
+            data-tour-tryitout-results>
+            <h4 id="results-heading">Results</h4>
+            <div class="hidden margin-top--2" data-tour="error" role="alert">
+                <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
+                    An error occurred when trying to display results. Please try again.
                 </div>
             </div>
-        </div>
+
+            <div class="hidden margin-top--2" data-tour-tryitout="results">
+                <div class="btn-group tour__tabs" role="tablist">
+                    <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
+                        class="btn btn--secondary btn--chart-control btn--secondary-active"
+                        data-tour-results-tab="json">JSON</a>
+                </div>
+                <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
+                    aria-labelledby="json-tab" aria-hidden="false">
+                    <div class="markdown">
+                        <pre class="tour__json-container" tabIndex="0"></pre>
+                    </div>
+                </div>
+            </div>
+        </section>
     </section>
 
     <hr class="margin-top--3">

--- a/static/tour/series-data-point/index.html
+++ b/static/tour/series-data-point/index.html
@@ -16,11 +16,12 @@ title: Take a tour of the API
 
     <p>You can use this to fetch a time series or data for multiple geographic areas.</p>
 
-    <section>
-        <h3>Example</h3>
+    <section aria-labelledby="example-heading">
+        <h3 id="example-heading">Example</h3>
         <p>
             Make a <code>GET</code> request to
-            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0</code>
+            <code
+                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">
@@ -37,31 +38,36 @@ title: Take a tour of the API
                     class="line-height--32">Run this JavaScript example</span></button>
         </div>
 
-        <div class="hidden margin-top--2" data-tour="error" role="alert">
-            <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
-                An error occurred when trying to display results. Please try again.
-            </div>
-        </div>
-
-        <div class="hidden margin-top--2" data-tour-tryitout="results">
-            <div class="btn-group tour__tabs" role="tablist">
-                <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
-                    class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
-                    data-tour-results-tab="json">JSON</a>
-                <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
-                    class="btn btn--secondary btn--chart-control tour__tab" data-tour-results-tab="results">Content</a>
-            </div>
-            <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
-                aria-labelledby="json-tab" aria-hidden="false">
-                <div class="markdown">
-                    <pre class="tour__json-container" tabIndex="0"></pre>
+        <section id="results-section" class="hidden" tabindex="-1" aria-labelledby="results-heading"
+            data-tour-tryitout-results>
+            <h4 id="results-heading">Results</h4>
+            <div class="hidden margin-top--2" data-tour="error" role="alert">
+                <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
+                    An error occurred when trying to display results. Please try again.
                 </div>
             </div>
-            <div id="results" data-tour-results-view="results" tabindex="0" class="tour__results-container"
-                role="tabpanel" aria-labelledby="results-tab" aria-hidden="true" data-tour-results-type="chart">
-                <!-- Highcharts plugin implemented -->
+
+            <div class="hidden margin-top--2" data-tour-tryitout="results">
+                <div class="btn-group tour__tabs" role="tablist">
+                    <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
+                        class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
+                        data-tour-results-tab="json">JSON</a>
+                    <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
+                        class="btn btn--secondary btn--chart-control tour__tab"
+                        data-tour-results-tab="results">Content</a>
+                </div>
+                <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
+                    aria-labelledby="json-tab" aria-hidden="false">
+                    <div class="markdown">
+                        <pre class="tour__json-container" tabIndex="0"></pre>
+                    </div>
+                </div>
+                <div id="results" data-tour-results-view="results" tabindex="0" class="tour__results-container"
+                    role="tabpanel" aria-labelledby="results-tab" aria-hidden="true" data-tour-results-type="chart">
+                    <!-- Highcharts plugin implemented -->
+                </div>
             </div>
-        </div>
+        </section>
     </section>
     <hr class="margin-top--3">
     <nav class="margin-top--2">

--- a/static/tour/single-data-point/index.html
+++ b/static/tour/single-data-point/index.html
@@ -14,11 +14,13 @@ title: Take a tour of the API
 
     <p>You need to specify a value for each of the available dimensions using query string parameters.</p>
 
-    <section>
-        <h3>Example</h3>
+    <section aria-labelledby="example-heading">
+        <h3 id="example-heading">Example</h3>
         <p>
             Make a <code>GET</code> request to
-            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=Aug-16&geography=K02000001&aggregate=cpih1dim1A0</code>
+            <code class="tour__endpoint-text">
+                https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=Aug-16&geography=K02000001&aggregate=cpih1dim1A0
+            </code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">
@@ -35,29 +37,35 @@ title: Take a tour of the API
                     class="line-height--32">Run this JavaScript example</span></button>
         </div>
 
-        <div class="hidden margin-top--2" data-tour="error" role="alert">
-            <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
-                An error occurred when trying to display results. Please try again.
-            </div>
-        </div>
-
-        <div class="hidden margin-top--2" data-tour-tryitout="results">
-            <div class="btn-group tour__tabs" role="tablist">
-                <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
-                    class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
-                    data-tour-results-tab="json">JSON</a>
-                <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
-                    class="btn btn--secondary btn--chart-control tour__tab" data-tour-results-tab="results">Content</a>
-            </div>
-            <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
-                aria-labelledby="json-tab" aria-hidden="false">
-                <div class="markdown">
-                    <pre class="tour__json-container" tabindex="0"></pre>
+        <section id="results-section" class="hidden" tabindex="-1" aria-labelledby="results-heading"
+            data-tour-tryitout-results>
+            <h4 id="results-heading">Results</h4>
+            <div class="hidden margin-top--2" data-tour="error" role="alert">
+                <div class="font-size--16 form-error filter-overview__error-message margin-top--1 margin-bottom--1">
+                    An error occurred when trying to display results. Please try again.
                 </div>
             </div>
-            <p id="results" data-tour-results-view="results" tabindex="0" data-tour-results-type="singlePoint"
-                class="tour__results-container" role="tabpanel" aria-labelledby="results-tab" aria-hidden="true"></p>
-        </div>
+
+            <div class="hidden margin-top--2" data-tour-tryitout="results">
+                <div class="btn-group tour__tabs" role="tablist">
+                    <a type="button" id="json-tab" role="tab" tabindex="0" aria-controls="json"
+                        class="btn btn--secondary btn--chart-control tour__tab" aria-selected="true"
+                        data-tour-results-tab="json">JSON</a>
+                    <a type="button" id="results-tab" role="tab" tabindex="0" aria-controls="results"
+                        class="btn btn--secondary btn--chart-control tour__tab"
+                        data-tour-results-tab="results">Content</a>
+                </div>
+                <div id="json" data-tour-results-view="json" class="tour__results-container" role="tabpanel"
+                    aria-labelledby="json-tab" aria-hidden="false">
+                    <div class="markdown">
+                        <pre class="tour__json-container" tabindex="0"></pre>
+                    </div>
+                </div>
+                <p id="results" data-tour-results-view="results" tabindex="0" data-tour-results-type="singlePoint"
+                    class="tour__results-container" role="tabpanel" aria-labelledby="results-tab" aria-hidden="true">
+                </p>
+            </div>
+        </section>
     </section>
     <hr class="margin-top--3">
     <nav class="margin-top--2">


### PR DESCRIPTION
### What

When using a screen reader, the flow of the tour is lost when the result
is generated. As a non-visual user, it is impossible to know that the
results section has been added.

Also fixes an issue whereby the "Run this JavaScript example" button
does not correctly display as disabled after it has been clicked.

### Who can review

Anyone but me.
