### PR TITLE
Changed all instances of `tt` to `code` as `tt` is obsolete.

### DIFF
--- a/js/tests/tour/Results.spec.js
+++ b/js/tests/tour/Results.spec.js
@@ -41,7 +41,7 @@ describe('building the results view', () => {
     };
     test('that the latest release text is rendered', () => {
       buildResultsView(el, response, resultType);
-      expect(el.innerHTML).toBe(`The latest release can be found at <tt>${response.links.latest_version.href}</tt>`);
+      expect(el.innerHTML).toBe(`The latest release can be found at <code>${response.links.latest_version.href}</code>`);
     });
   });
   describe('building the single point results view', () => {
@@ -58,7 +58,7 @@ describe('building the results view', () => {
     test('that the single point text is rendered', () => {
       buildResultsView(el, response, resultType);
       expect(el.innerHTML)
-          .toBe(`The value of CPIH for the United Kingdom in August 2016 was <tt>${response.observations[0].observation}</tt>`);
+          .toBe(`The value of CPIH for the United Kingdom in August 2016 was <code>${response.observations[0].observation}</code>`);
     });
   });
   describe('building the chart results view', () => {

--- a/js/tour/Results.js
+++ b/js/tour/Results.js
@@ -46,9 +46,9 @@ const buildText = (resultsContainer, text) => {
   const resultType = resultsContainer.dataset.tourResultsType;
 
   if (resultType === 'latestRelease') {
-    paragraph.innerHTML = `The latest release can be found at <tt>${text}</tt>`;
+    paragraph.innerHTML = `The latest release can be found at <code>${text}</code>`;
   } else if (resultType === 'singlePoint') {
-    paragraph.innerHTML = `The value of CPIH for the United Kingdom in August 2016 was <tt>${text}</tt>`;
+    paragraph.innerHTML = `The value of CPIH for the United Kingdom in August 2016 was <code>${text}</code>`;
   }
 };
 

--- a/static/tour/getting-started/index.html
+++ b/static/tour/getting-started/index.html
@@ -12,7 +12,7 @@ title: Take a tour of the API
     <section>
         <h3>Example</h3>
         <p>
-            Make a <tt>GET</tt> request to <tt class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets</tt>
+            Make a <code>GET</code> request to <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">

--- a/static/tour/latest-release/index.html
+++ b/static/tour/latest-release/index.html
@@ -10,13 +10,12 @@ title: Take a tour of the API
     <p>Once you have a dataset ID, you can find the latest release of a dataset using the <a
             href="../../dataset/datasets-id/">get dataset</a> endpoint.</p>
 
-    <p>A link to the latest release can be found in <tt>links.latest_version</tt> field.</p>
+    <p>A link to the latest release can be found in <code>links.latest_version</code> field.</p>
 
     <div>
         <h3>Example</h3>
         <p>
-            Make a <tt>GET</tt> request to <tt
-                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01</tt>
+            Make a <code>GET</code> request to <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">

--- a/static/tour/latest-version/index.html
+++ b/static/tour/latest-version/index.html
@@ -10,15 +10,14 @@ title: Take a tour of the API
     <p>
         Once you have the link to the latest release, you can fetch its metadata using the
         <a href="../../dataset/datasets-id-editions-edition-versions-version">get version</a> endpoint
-        using the URL from <tt>links.latest_version</tt>.
+        using the URL from <tt>links.latest_version</code>.
     </p>
 
     <section>
         <h3>Example</h3>
         <p>
-            Make a <tt>GET</tt> request to
-            <tt
-                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6</tt>
+            Make a <code>GET</code> request to
+            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">

--- a/static/tour/latest-version/index.html
+++ b/static/tour/latest-version/index.html
@@ -10,7 +10,7 @@ title: Take a tour of the API
     <p>
         Once you have the link to the latest release, you can fetch its metadata using the
         <a href="../../dataset/datasets-id-editions-edition-versions-version">get version</a> endpoint
-        using the URL from <tt>links.latest_version</code>.
+        using the URL from <code>links.latest_version</code>.
     </p>
 
     <section>

--- a/static/tour/series-data-point/index.html
+++ b/static/tour/series-data-point/index.html
@@ -19,9 +19,8 @@ title: Take a tour of the API
     <section>
         <h3>Example</h3>
         <p>
-            Make a <tt>GET</tt> request to
-            <tt
-                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0</tt>
+            Make a <code>GET</code> request to
+            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=*&geography=K02000001&aggregate=cpih1dim1A0</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">

--- a/static/tour/single-data-point/index.html
+++ b/static/tour/single-data-point/index.html
@@ -17,9 +17,8 @@ title: Take a tour of the API
     <section>
         <h3>Example</h3>
         <p>
-            Make a <tt>GET</tt> request to
-            <tt
-                class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=Aug-16&geography=K02000001&aggregate=cpih1dim1A0</tt>
+            Make a <code>GET</code> request to
+            <code class="tour__endpoint-text">https://api.beta.ons.gov.uk/v1/datasets/cpih01/editions/time-series/versions/6/observations?time=Aug-16&geography=K02000001&aggregate=cpih1dim1A0</code>
         </p>
         <details class="margin-bottom--4" data-tour-example>
             <summary class="summary">


### PR DESCRIPTION
### What

Changed `<tt>` to `<code>` as it is obsolete in HTML5.

### How to review

Check that all `<tt>` have been caught and replaced.

### Who can review

Anyone other than me.
