### PR TITLE
Update search api link

### DIFF
--- a/static/retirement/aggregatedsearch/index.md
+++ b/static/retirement/aggregatedsearch/index.md
@@ -11,7 +11,7 @@ In line with our [approach to the retirement of API endpoints](../), it has been
 - strategic technology direction is elsewhere
 - cost of upkeep is too high with similar services available
 
-The UI for these pages has already been moved to use our Search API and it is the intention of ONS to separate data and UI endpoints by domain in future. Data in JSON format will be accessible via our API found at <https://api.beta.ons.gov.uk/v1/search>. You can also browse the [full API Swagger specification](../../search/search).
+The UI for these pages has already been moved to use our Search API and it is the intention of ONS to separate data and UI endpoints by domain in future. Data in JSON format will be accessible via our API found at <https://api.beta.ons.gov.uk/v1/search>. You can also browse the [full API Swagger specification](../../search/search/).
 
 The endpoints to be decommissioned will be:
 


### PR DESCRIPTION
### What
Attempt 2
Fixes a broken link on `/retirement/aggregatedsearch/` for the search api
Previously was working in local but wasn't working in sandbox or prod.

### How to review

Sense check

### Who can review

Anyone