### PR TITLE
Fix incorrect example API responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ audit:
 .PHONY: build
 build: deps-javascript
 	go run main.go
-	
+
 .PHONY: deps-javascript
 deps-javascript:
 	$(NPM) install --unsafe-perm
@@ -57,3 +57,7 @@ watch-serve:
 .PHONY: serve
 serve:
 	serve -port=${PORT} -dir="assets"
+
+.PHONY: clean
+clean:
+	rm -rf assets/ logs/ node_modules/


### PR DESCRIPTION
### What

The example responses being displayed in the API endpoint docs was actually a JSON serialised view of the entire spec model for the response schema rather than an example response.

This fix will generate an example for all responses where a schema is specified. It will determine the value for each property using the following precedence (if attribute is not set it will go to the next):

1. `example` value
2. `default` value
3. first `enum` value
4. sensible defaults based on the `type` and `format` where specified
5. `type` value

Using this method all properties can be represented in the example so long as the API spec is valid.

Also adds a make target to clean up the generated site for local testing when you want to ensure you have a clean start.

### How to review

Run the site locally and look at your local version of a page like this one: https://developer.ons.gov.uk/dataset/datasets-id-editions-edition-versions/

Check that the response example resembles the expected API response body rather than the full API spec currently displayed.

### Who can review

!me
